### PR TITLE
API Key Authentication

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -35,6 +35,7 @@ app.use app.router
 app.use express.errorHandler()
 
 apiKey = process.env.EPISTREAM_API_KEY
+urlBasedKey = process.env.URL_BASED_API_KEY # use second env var for backwards compatibility 
 
 socketServer = sockjs.createServer(app)
 
@@ -69,7 +70,15 @@ app.get '/stats', (req, res) ->
 httpRequestHandler = (req, res) ->
   clientId = req.param 'client_id'
   c = new Context()
-  _.extend c, httpClient.getQueryRequestInfo(req)
+  _.extend c, httpClient.getQueryRequestInfo(req, !!apiKey)
+  # Check that the client supplied key matches server key
+  if apiKey
+    if !(c.clientKey == apiKey)
+      log.error "Unauthorized HTTP Access Attempted from IP: #{req.connection.remoteAddress}"
+      log.error "Unauthorized Context: #{JSON.stringify(c.templateContext)}"
+      res.send error: "Unauthorized Access"
+      return
+
   if c.connectionName and not config.connections[c.connectionName]
     res.send error: "unable to find connection by name '#{c.connectionName}'"
     return

--- a/server.coffee
+++ b/server.coffee
@@ -93,6 +93,8 @@ socketServer.on 'connection', (conn) ->
     if apiKey
       if !~ conn.url.indexOf apiKey
         conn.close()
+        log.error "Unauthorized Socket Access Attempted from IP: #{conn.remoteAddress}"
+        log.error "Unauthorized Context: #{JSON.stringify(message)}"
         return
 
     log.debug "inbound message #{message}"
@@ -118,5 +120,10 @@ app.post /\/(.+)$/, httpRequestHandler
 log.info "server worker process starting with configuration"
 log.info "%j", config
 server = http.createServer(app)
-socketServer.installHandlers(server, {prefix: '/sockjs'})
+
+# use key based prefix if key is in url
+prefix = {prefix: '/sockjs'}
+prefix.prefix = "/#{apiKey}/sockjs" if apiKey && urlBasedKey
+
+socketServer.installHandlers(server, prefix)
 server.listen(config.port)

--- a/src/transport/http.coffee
+++ b/src/transport/http.coffee
@@ -56,9 +56,12 @@ attachResponder = (context, res) ->
 
   c.on 'completequeryexecution', completeResponse
 
-getQueryRequestInfo = (req) ->
+getQueryRequestInfo = (req, useSecure) ->
   templatePath = req.path.replace(/\.\./g, '').replace(/^\//, '')
   pathParts = templatePath.split('/')
+  # If we're using a key secured client, the key must be before the connection name
+  if useSecure
+    clientKey = pathParts.shift()
   connectionName = pathParts.shift()
   connection = null
   if connectionName is 'header'
@@ -72,6 +75,7 @@ getQueryRequestInfo = (req) ->
     connectionConfig: connection
     templateContext: params
     templateName: templatePath
+    clientKey: clientKey
 
 module.exports.attachResponder = attachResponder
 module.exports.getQueryRequestInfo = getQueryRequestInfo


### PR DESCRIPTION
I made it backward compatible with the current version. HTTP was fine, but there was already api key checking on the socket connection. I tweaked it to use a different kind of key checking only if URL_BASED_API_KEY is present in environment vars.