### PR TITLE
Return the actual error message in a new field

### DIFF
--- a/src/transport/http.coffee
+++ b/src/transport/http.coffee
@@ -48,7 +48,7 @@ attachResponder = (context, res) ->
     writeEvent data
 
   c.on 'error', (err) ->
-    d = message: 'error'
+    d = message: 'error', errorDetail: err
     d.error = err.message if err.message
     log.error err
     writeEvent d


### PR DESCRIPTION
Right now epistreaming only returns an error message saying "error." This makes it harder to track down what the actual problem with the template is. This fork returns a new field - "errorDetail" which has the actual sql error - when there's an error.