### PR TITLE
Emit template path on Error

### DIFF
--- a/src/query.coffee
+++ b/src/query.coffee
@@ -88,7 +88,7 @@ attachAndExecute = (driverInstance, context, cb) ->
     context.emit 'data', {queryId: queryId, data: data}
 
   errorHandler = (err) ->
-    log.error "[q:#{context.queryId}] te %j", err
+    log.error "[q:#{context.queryId}] te [#{context.templatePath}] %j", err
     pool = DRIVER_POOL[context.connection.name]
     pool.destroy(driverInstance) if pool
 


### PR DESCRIPTION
When many are streaming - this helps quickly identify which template is having which error.  After doing some testing the template EXECUTION STATS will 'follow' the error but comes as an INFO log.  

With this change you can quickly just grep for ERROR and still get 'which' template breaks.