### PR TITLE
Adding optional role name -> bitmask mapping

### DIFF
--- a/src/templates.coffee
+++ b/src/templates.coffee
@@ -97,7 +97,7 @@ parseFrontMatter = (templateString) ->
 
       if roles and not _.isNumber(roles)  #non-numeric role-def needs to be parsed and applied
         frontMatterParsed.executionMasks['jwt-role-glg'] = _.reduce(roles.split(','), (acc,v) ->
-          return acc + ( roleMapping[_.trim(v.toUpperCase())] or 0 )
+          return acc | ( roleMapping[_.trim(v.toUpperCase())] or 0 )
         , 0)
 
       # strip off the front matter, running past the leng of string with the end pos

--- a/src/templates.coffee
+++ b/src/templates.coffee
@@ -8,6 +8,17 @@ config    = require './config.coffee'
 util      = require 'util'
 yaml      = require 'js-yaml'
 
+# TODO: store in environment or pull from services/auth/roles dynamically
+roleMapping = {
+  COUNCILMEMBER: 4,
+  APP: 16,
+  DENY_ALL: 0,
+  ALLOW_ALL: 2147483647,
+  USER: 1,
+  SURVEYRESPONDENT: 8,
+  CLIENT: 2
+}
+
 getRelativeTemplatePath = (templatePath) ->
   # as per the MDN
   #   If either argument is greater than stringName.length,
@@ -81,6 +92,13 @@ parseFrontMatter = (templateString) ->
 
       frontMatterParsed = yaml.load(frontMatter + "\n", 'utf8')
       log.debug "parsed frontmatter: %j", frontMatterParsed
+
+      roles = frontMatterParsed?.executionMasks?['jwt-role-glg']
+
+      if roles and not _.isNumber(roles)  #non-numeric role-def needs to be parsed and applied
+        frontMatterParsed.executionMasks['jwt-role-glg'] = _.reduce(roles.split(','), (acc,v) ->
+          return acc + ( roleMapping[_.trim(v.toUpperCase())] or 0 )
+        , 0)
 
       # strip off the front matter, running past the leng of string with the end pos
       # simply results in the whole string


### PR DESCRIPTION
Quick update by bchang and I to use optionally use roll names for execution masks.  Still supports the existing int definitions as well.  Note from the TODO that we could use env or a cached request to get the role mappings if keeping this glg agnostic is a thing.