### PR TITLE
update CORS to appease fetch, which is strict

### DIFF
--- a/epistream.coffee
+++ b/epistream.coffee
@@ -33,7 +33,8 @@ core.init()
 if config.isDevelopmentMode()
   log.warn "epiquery2 running in development mode, this will cause requests to be slower"
   set_cors_headers = (req, res, next) ->
-    res.header 'Access-Control-Allow-Origin', '*'
+    res.header 'Access-Control-Allow-Origin', req.get('Origin') ? '*'
+    res.header 'Access-Control-Allow-Credentials', true
     res.header 'Access-Control-Allow-Headers', 'Content-Type'
     res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS')
     next()


### PR DESCRIPTION
returns the request origin instead of '*'

allows credentials, as described https://fetch.spec.whatwg.org/#cors-protocol-and-credentials