### PR TITLE
Include aliases as types.  So I can use 'date' instead of the officia…

### DIFF
--- a/src/drivers/mssql_base.coffee
+++ b/src/drivers/mssql_base.coffee
@@ -13,6 +13,8 @@ lowerCaseTediousTypeMap = {}
 for propertyName in Object.getOwnPropertyNames(tedious.TYPES)
   type = tedious.TYPES[propertyName]
   lowerCaseTediousTypeMap[type.name.toLowerCase()] = type
+  _.forEach type.aliases, (alias) =>
+    lowerCaseTediousTypeMap[alias.toLowerCase()] = type
 
 class MSSQLDriver extends events.EventEmitter
   constructor: (@config) ->


### PR DESCRIPTION
Include aliases as type options. So I can use 'date' instead of the official 'dateN' type which is weird...