### PR TITLE
Better Handling for bad parameter types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "0.0.13",
   "description": "run templated queries from the http's using learnings from 1",
   "devDependencies": {
+    "chai": "^4.0.2",
     "coffeelint": "0.6.1",
-    "jshint": "2.3.0",
-    "sockjs-client": "0.1.3",
     "difftest-runner": "0.0.9",
+    "jshint": "2.3.0",
+    "mocha": "^3.4.2",
+    "sockjs-client": "0.1.3",
     "ws": "~0.4.31"
   },
   "dependencies": {
@@ -36,6 +38,7 @@
   },
   "scripts": {
     "start": "make start",
+    "test": "mocha",
     "watch": "make watch"
   },
   "engines": {

--- a/src/drivers/mssql_base.coffee
+++ b/src/drivers/mssql_base.coffee
@@ -6,9 +6,9 @@ os              = require 'os'
 
 lowerCaseTediousTypeMap = {}
 
-# to make it so folks don't have to learn tedious' crazy casing of 
+# to make it so folks don't have to learn tedious' crazy casing of
 # data types, we'll keep a map of lower cased type names for comparison
-# to the inbound parameter type names ( in the case of a parameterized 
+# to the inbound parameter type names ( in the case of a parameterized
 # query request )
 for propertyName in Object.getOwnPropertyNames(tedious.TYPES)
   type = tedious.TYPES[propertyName]
@@ -109,6 +109,9 @@ class MSSQLDriver extends events.EventEmitter
       parameters.forEach (param) =>
         lowerCaseTypeName = param.type.toLowerCase()
         tediousType = lowerCaseTediousTypeMap[lowerCaseTypeName]
+
+        throw new TypeError("Unknown parameter type (#{param.type}) for #{param.varName}") if not tediousType
+
         log.debug "adding parameter #{param.varName}, value #{param.value} as type #{tediousType.name}"
         request.addParameter(param.varName, tediousType, param.value)
       @conn.execSql request

--- a/test/drivers/mssql_base.test.js
+++ b/test/drivers/mssql_base.test.js
@@ -1,0 +1,28 @@
+const expect = require('chai').expect;
+const DriverClass = require('../../src/drivers/mssql_base.coffee').DriverClass;
+
+describe('MSSQL base', function() {
+  beforeEach(function() {
+    this.db = new DriverClass({});
+  });
+
+  describe('.execute', function() {
+    it('should throw on invalid types', function() {
+      const query = `
+--parameters:
+--@valid bit valid
+--@foo catpants bar
+
+select * from tasks.task;`;
+      const context = {
+        templateName: 'templateName',
+        unEscapedTemplateContext: query
+      };
+      const db = this.db;
+
+      expect(() => {
+        this.db.execute(query, context);
+      }).to.throw(TypeError).with.property('message', 'Unknown parameter type (catpants) for foo');
+    });
+  });
+});

--- a/test/drivers/mssql_base.test.js
+++ b/test/drivers/mssql_base.test.js
@@ -13,12 +13,11 @@ describe('MSSQL base', function() {
 --@valid bit valid
 --@foo catpants bar
 
-select * from tasks.task;`;
+select * from meh;`;
       const context = {
         templateName: 'templateName',
         unEscapedTemplateContext: query
       };
-      const db = this.db;
 
       expect(() => {
         this.db.execute(query, context);

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--require coffee-script/register
+--recursive


### PR DESCRIPTION
Currently when an unknown parameter type (like `datetime2`) is used for a parameter, epi freezes and/or does nothing until nginx closes the connection. This makes it fail immediately with a the following error message:

> Unknown parameter type (catpants) for foo

Related to #32