### PR TITLE
Add parsed port when hitting episcreamer endpoint

### DIFF
--- a/src/request.coffee
+++ b/src/request.coffee
@@ -136,6 +136,7 @@ postToScreamer = (context) -> () ->
   options =
     hostname: screamerUrl.hostname
     path: screamerUrl.pathname
+    port: screamerUrl.port
     method: 'POST'
     headers:
       'Content-Type': 'application/json'


### PR DESCRIPTION
I noticed that the port was missing from the params that were being passed while running episcreamer locally.